### PR TITLE
logLevel for info and error were wrong

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -30,7 +30,7 @@ module.exports = {
     badge: figures.info,
     color: 'blue',
     label: 'info',
-    logLevel: 'debug'
+    logLevel: 'info'
   },
   star: {
     badge: figures.star,
@@ -54,7 +54,7 @@ module.exports = {
     badge: figures.warning,
     color: 'yellow',
     label: 'warning',
-    logLevel: 'debug'
+    logLevel: 'warn'
   },
   complete: {
     badge: figures.checkboxOn,


### PR DESCRIPTION
This PR addresses the problem reported [here](https://github.com/rudemex/signale-logger/issues/2), setting a `logLevel` other than `debug` seems to hide everything.

The issue is not with the code itself, but instead the default configuration for `info` and `warn` that have a `logLevel` of... `debug`.
Setting this to the expected levels fixes the issue for me.